### PR TITLE
pawn-requests support (resolves #17)

### DIFF
--- a/MV_Youtube.inc
+++ b/MV_Youtube.inc
@@ -3,7 +3,7 @@
 #endif
 #define MV_Youtube_Included
 
-#include <a_http>
+#include <a_samp>
 #include <requests>
 #tryinclude <map>
 

--- a/MV_Youtube.inc
+++ b/MV_Youtube.inc
@@ -4,14 +4,15 @@
 #define MV_Youtube_Included
 
 #include <a_http>
-#include <a_json>
+#include <requests>
+#tryinclude <map>
 
 #if !defined MAX_YOUTUBE_SAVES
 	#define MAX_YOUTUBE_SAVES	50
 #endif 
 
 #if !defined CONVERTER_PATH
-	#define CONVERTER_PATH		"youtube.michaelbelgium.me/api/converter"
+	#define CONVERTER_PATH		"https://youtube.michaelbelgium.me/api/converter/"
 #endif 
 
 #if !defined MAX_SEARCH_RESULTS
@@ -22,12 +23,28 @@
 	#define API_KEY 	""
 #endif
 
+#if !defined MAX_PLAYLISTS
+	#define MAX_PLAYLISTS		5
+#endif
+
 #define INVALID_YT_ID		-1
 #define INVALID_PLAYLIST_ID	-1
-#define MAX_PLAYLISTS		5
+
+static RequestsClient:Converter;
+
+#if defined __MAP_INCLUDED__
+	static Map:LoadRequestToPlayerID;
+	static Map:LoadRequestToYoutubeID;
+#else
+	static Request:PlayerIDToRequest[MAX_PLAYERS] = {Request:-1, ...};
+#endif
 
 enum e_ytv
 {
+	#if !defined __MAP_INCLUDED__
+		Request:RequestID,
+	#endif
+
 	bool:Playing,
 	ytID[16],
 	Duration,
@@ -59,10 +76,45 @@ enum pSearchResult
 
 new SearchResults[MAX_PLAYERS][MAX_SEARCH_RESULTS][pSearchResult];
 
+static stock EncodeYoutubeURL(url[], maxlength = sizeof(url))
+{
+	new const SEARCH[] = ":", REPLACEMENT[] = "%3A", SUB_LEN = strlen(SEARCH), REP_LEN = strlen(REPLACEMENT);
+    new pos, len = strlen(url), count;
+    
+    while(-1 != (pos = strfind(url, SEARCH, false, pos))) {
+        strdel(url, pos, pos + SUB_LEN);
+        
+        len -= SUB_LEN;
+        
+        if(REP_LEN && len + REP_LEN < maxlength) {
+            strins(url, REPLACEMENT, pos, maxlength);
+            
+            pos += REP_LEN;
+            len += REP_LEN;
+        }
+    }
+    
+    return count;
+}
+
+static stock InitYoutube()
+{
+	for(new i = 0; i < MAX_YOUTUBE_SAVES; i++)
+	{
+		#if !defined __MAP_INCLUDED__
+			Youtube[i][RequestID] = Request:-1;
+		#endif
+
+		Youtube[i][PlaylistID] = INVALID_PLAYLIST_ID;
+	}
+
+	Converter = RequestsClient(CONVERTER_PATH, RequestHeaders("Authorization", "Bearer "API_KEY""));
+}
+
 forward OnYoutubeVideoFinished(youtubeid);
 forward SongFinished(youtubeid);
-forward OnVpsResponse(index, response_code, const data[]);
-forward OnSearchResponse(index, response_code, const data[]);
+forward OnVpsResponse(Request:id, E_HTTP_STATUS:status, Node:node);
+forward OnSearchResponse(Request:id, E_HTTP_STATUS:status, Node:node);
 forward OnMVYoutubeError(youtubeid, const message[]);
 forward OnYoutubeVideoStart(youtubeid);
 forward OnPlaylistAddEntry(playerlistid, youtubeid);
@@ -88,9 +140,16 @@ stock PlayYoutubeVideoFor(const url[], playfor = INVALID_PLAYER_ID, playlist = I
 
 		format(Youtube[id][Link],256,"%s",url);
 
-		format(requestlink,sizeof(requestlink),"%s/convert?url=%s&api_token=%s",CONVERTER_PATH,Youtube[id][Link],API_KEY);
+		format(requestlink,sizeof(requestlink),"convert?url=%s",Youtube[id][Link]);
+		EncodeYoutubeURL(requestlink);
 		
-		HTTP(id, HTTP_GET, requestlink, "", "OnVpsResponse");
+		new const Request:ID = RequestJSON(Converter, requestlink, HTTP_METHOD_GET, "OnVpsResponse", .headers = RequestHeaders());
+
+		#if defined __MAP_INCLUDED__
+			MAP_insert_val_val(LoadRequestToYoutubeID, _:ID, id);
+		#else
+			Youtube[id][RequestID] = ID;
+		#endif
 	}
 	return id;
 }
@@ -98,8 +157,15 @@ stock PlayYoutubeVideoFor(const url[], playfor = INVALID_PLAYER_ID, playlist = I
 stock SearchYoutubeVideos(playerid, const searchquery[])
 {
 	new requestlink[512];
-	format(requestlink, sizeof(requestlink), "%s/search?q=%s&max_results=%i&api_token=%s", CONVERTER_PATH, searchquery, MAX_SEARCH_RESULTS,API_KEY);
-	HTTP(playerid, HTTP_GET, requestlink, "", "OnSearchResponse");
+	format(requestlink, sizeof(requestlink), "search?q=%s&max_results=%i", searchquery, MAX_SEARCH_RESULTS);
+	EncodeYoutubeURL(requestlink);
+
+	new const Request:ID = RequestJSON(Converter, requestlink, HTTP_METHOD_GET, "OnSearchResponse", .headers = RequestHeaders());
+	#if defined __MAP_INCLUDED__
+		MAP_insert_val_val(LoadRequestToPlayerID, _:ID, playerid);
+	#else
+		PlayerIDToRequest[playerid] = ID;
+	#endif
 }
 
 stock GetFreeIndex()
@@ -120,7 +186,11 @@ stock StopYoutubeVideo(youtubeid)
 
 	if(Youtube[youtubeid][PlayFor] == INVALID_PLAYER_ID)
 	{
-		for(new i = 0, j = GetPlayerPoolSize(); i <= j; i++)
+		#if defined _INC_open_mp
+			for (new i = 0; i < MAX_PLAYERS; i++)
+		#else
+			for(new i = 0, j = GetPlayerPoolSize(); i <= j; i++)
+		#endif
 		{
 			if(!IsPlayerConnected(i)) continue;
 			StopAudioStreamForPlayer(i);
@@ -222,7 +292,11 @@ PlayYoutubeVideo(youtubeid) //shouldn't use this function outside of the include
 
 	if(Youtube[youtubeid][PlayFor] == INVALID_PLAYER_ID)
 	{
-		for(new i = 0, j = GetPlayerPoolSize(); i <= j; i++)
+		#if defined _INC_open_mp
+			for (new i = 0; i < MAX_PLAYERS; i++)
+		#else
+			for(new i = 0, j = GetPlayerPoolSize(); i <= j; i++)
+		#endif
 		{
 			if(IsPlayerConnected(i))
 			{
@@ -240,32 +314,48 @@ PlayYoutubeVideo(youtubeid) //shouldn't use this function outside of the include
 	Youtube[youtubeid][Timer] = SetTimerEx("SongFinished",GetVideoDuration(youtubeid)*1000,false,"i",youtubeid);
 }
 
-public OnVpsResponse(index, response_code, const data[])
+public OnVpsResponse(Request:id, E_HTTP_STATUS:status, Node:node)
 {
+	#if defined __MAP_INCLUDED__
+		new index = MAP_get_val_val(LoadRequestToYoutubeID, _:id);
+		MAP_remove_val(LoadRequestToYoutubeID, _:id);
+	#else
+		new index = -1;
+
+		for(new i = 0; i < sizeof(Youtube); i++)
+		{
+			if(Youtube[i][RequestID] == id)
+			{
+				Youtube[i][RequestID] = Request:-1;
+				index = i;
+				break;
+			}
+		}
+	#endif
+
 	new string[256];
 
-	if(response_code != 200)
+	if(status != HTTP_STATUS_OK)
 	{
-		format(string, sizeof(string), "%s - response code: %i", GetError(response_code), response_code);
+		format(string, sizeof(string), "%s - response code: %i", GetError(status), _:status);
 		CallLocalFunction("OnMVYoutubeError", "is", index, string);
 		return 0;
 	}
 
-	new JSONNode:response = json_parse_string(data);
+	new bool:error;
+	JsonGetBool(node, "error", error);
 
-	if(json_get_bool(response, "error"))
+	if(error)
 	{
-		json_get_string(response, string, sizeof(string), "message");
+		JsonGetString(node, "message", string);
 		CallLocalFunction("OnMVYoutubeError", "is", index, string);
 		return 0;
 	}
 
-	json_get_string(response, Youtube[index][Title], 256, "title");
-	Youtube[index][Duration] = json_get_int(response, "duration");
-	Youtube[index][ytID] = json_get_int(response, "youtube_id");
-	json_get_string(response, Youtube[index][StreamLink], 512, "file");
-
-	json_close(response);
+	JsonGetString(node, "title", Youtube[index][Title]);
+	JsonGetInt(node, "duration", Youtube[index][Duration]);
+	JsonGetInt(node, "youtube_id", Youtube[index][ytID]);
+	JsonGetString(node, "file", Youtube[index][StreamLink]);
 
 	if(Youtube[index][PlaylistID] != INVALID_PLAYLIST_ID)
 	{
@@ -279,37 +369,61 @@ public OnVpsResponse(index, response_code, const data[])
 	return 1;
 }
 
-public OnSearchResponse(index, response_code, const data[])
+public OnSearchResponse(Request:id, E_HTTP_STATUS:status, Node:node)
 {
-	new JSONNode:response = json_parse_string(data), JSONArray:results, string[128];
+	#if defined __MAP_INCLUDED__
+		new index = MAP_get_val_val(LoadRequestToPlayerID, _:id);
+		MAP_remove_val(LoadRequestToPlayerID, _:id);
+	#else
+		new index = -1;
 
-	if(response_code != 200)
+		for(new i = 0; i < sizeof(PlayerIDToRequest); i++)
+		{
+			if(PlayerIDToRequest[i] == id)
+			{
+				PlayerIDToRequest[i] = Request:-1;
+				index = i;
+				break;
+			}
+		}
+	#endif
+	
+	new string[256];
+
+	if(status != HTTP_STATUS_OK)
 	{
-		format(string, sizeof(string), "%s - response code: %i", GetError(response_code), response_code);
+		format(string, sizeof(string), "%s - response code: %i", GetError(status), _:status);
 		CallLocalFunction("OnMVYoutubeError", "is", index, string);
 		return 0;
 	}
 
-	if(json_get_bool(response, "error"))
+	new bool:error;
+	JsonGetBool(node, "error", error);
+
+	if(error)
 	{
-		json_get_string(response, string, sizeof(string), "message");
+		JsonGetString(node, "message", string);
 		CallLocalFunction("OnMVYoutubeError", "is", index, string);
 		return 0;
 	}
 
-	results = json_get_array(response, "results");
+	JsonToggleGC(node, false);
 
-	new title[128], link[256];
-	for(new i = 0; i < json_array_count(results); i++)
+	new Node:results, length;
+
+	JsonGetArray(node, "results", results);
+	JsonArrayLength(results, length);
+
+	for(new i = 0; i < length; i++)
 	{
-		new JSONNode:node = json_array_at(results, i);
+		new Node:result;
+		JsonArrayObject(results, i, result);
 
-		json_get_string(node, title, sizeof(title), "title");
-		json_get_string(node, link, sizeof(link), "full_link");
-
-		format(SearchResults[index][i][Title], sizeof(title), "%s", title);
-		format(SearchResults[index][i][Link], sizeof(link), "%s", link);
+		JsonGetString(result, "title", SearchResults[index][i][Title]);
+		JsonGetString(result, "full_link", SearchResults[index][i][Link]);
 	}
+
+	JsonToggleGC(node, true);
 
 	CallLocalFunction("OnYoutubeSearch", "i", index);
 	return 1;
@@ -339,7 +453,7 @@ public SongFinished(youtubeid)
 	}
 }
 
-stock GetError(val)
+stock GetError({_, E_HTTP_STATUS}:val)
 {
 	new error[32];
 	switch(val)
@@ -350,31 +464,73 @@ stock GetError(val)
 		case 4: error = "Can't write";
 		case 5: error = "Content too big";
 		case 6: error = "Malformed response";
-		case 300..308: error = "Redirection";
-		case 400..499: error = "Client error";
-		case 500..599: error = "Server error";
+		case (_:HTTP_STATUS_MULTIPLE_CHOICES)..(_:HTTP_STATUS_PERMANENT_REDIRECT): error = "Redirection";
+		case (_:HTTP_STATUS_BAD_REQUEST)..(_:HTTP_STATUS_LEGAL_FAILURE): error = "Client error";
+		case (_:HTTP_STATUS_SERVER_ERROR)..(_:HTTP_STATUS_AUTH_REQUIRED): error = "Server error";
 	}
 	return error;
 }
 
-public OnGameModeInit()
-{
-	for(new i = 0; i < MAX_YOUTUBE_SAVES; i++)	Youtube[i][PlaylistID] = INVALID_PLAYLIST_ID;
+#if defined FILTERSCRIPT
+	public OnGameModeInit()
+	{
+		InitYoutube();
 
-	#if defined MV_OnGameModeInit
-		return MV_OnGameModeInit();
+		#if defined MV_OnGameModeInit
+			return MV_OnGameModeInit();
+		#else
+			return 1;
+		#endif
+	}
+
+	#if defined _ALS_OnGameModeInit
+		#undef OnGameModeInit
 	#else
-		return 1;
+		#define _ALS_OnGameModeInit
+	#endif
+
+	#define OnGameModeInit MV_OnGameModeInit
+	#if defined MV_OnGameModeInit
+		forward MV_OnGameModeInit();
+	#endif
+#else
+	public OnGameModeInit()
+	{
+		InitYoutube();
+
+		#if defined MV_OnGameModeInit
+			return MV_OnGameModeInit();
+		#else
+			return 1;
+		#endif
+	}
+
+	#if defined _ALS_OnGameModeInit
+		#undef OnGameModeInit
+	#else
+		#define _ALS_OnGameModeInit
+	#endif
+
+	#define OnGameModeInit MV_OnGameModeInit
+	#if defined MV_OnGameModeInit
+		forward MV_OnGameModeInit();
+	#endif
+#endif
+
+public OnRequestFailure(Request:id, errorCode, errorMessage[], len)
+{
+	#if defined MV_OnRequestFailure
+		MV_OnRequestFailure(id, errorCode, errorMessage, len);
 	#endif
 }
 
-#if defined _ALS_OnGameModeInit
-	#undef OnGameModeInit
+#if defined _ALS_OnRequestFailure
+	#undef OnRequestFailure
 #else
-	#define _ALS_OnGameModeInit
+	#define _ALS_OnRequestFailure
 #endif
 
-#define OnGameModeInit MV_OnGameModeInit
-#if defined MV_OnGameModeInit
-	forward MV_OnGameModeInit();
+#define OnRequestFailure MV_OnRequestFailure
+#if defined MV_OnRequestFailure
+	forward MV_OnRequestFailure(Request:id, errorCode, errorMessage[], len);
 #endif

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 
 ```PAWN
-native PlayYoutubeVideoFor(url[], playfor = INVALID_PLAYER_ID, playlist = INVALID_PLAYLIST_ID, bool:usepos = false, Float:distance = 50.0) 
+native PlayYoutubeVideoFor(const url[], playfor = INVALID_PLAYER_ID, playlist = INVALID_PLAYLIST_ID, bool:usepos = false, Float:distance = 50.0) 
 	-> returns a youtubeid
 native StopYoutubeVideo(youtubeid)
 
-native IsValidYoutubeURL(string[])
+native IsValidYoutubeURL(const string[])
 native IsYouTubeVideoPlaying(youtubeid)
 
 native GetVideoDuration(youtubeid)
@@ -19,7 +19,7 @@ native GetVideoLink(youtubeid)
 native GetVideoStreamLink(youtubeid)
 native GetVideoTarget(youtubeid)
 
-native CreatePlaylist(name[])
+native CreatePlaylist(const name[])
 	-> returns a playlistid
 native RemovePlaylist(playlistid)
 native GetPlaylistName(playlistid)
@@ -32,14 +32,15 @@ public OnYoutubeSearch(playerid)
 
 public OnYoutubeVideoStart(youtubeid)
 public OnYoutubeVideoFinished(youtubeid)
-public OnMVYoutubeError(youtubeid, message[])
+public OnMVYoutubeError(youtubeid, const message[])
 public OnPlaylistAddEntry(playlistid, youtubeid)
 public OnPlaylistFinished(playlistid)
 ```
 
 # Requirements
 
-* [SAMPSON](https://github.com/Hual/SAMPSON)
+* [pawn-requests](https://github.com/Southclaws/pawn-requests)
+* [Hash-map implementation in PAWN](https://github.com/BigETI/pawn-map) (optional)
 
 # Installing
 
@@ -63,11 +64,9 @@ You are free to use the existing settings of this include that uses the installe
 
 ```PAWN
 #define MAX_YOUTUBE_SAVES	50
-#define INVALID_YT_ID		-1
-#define INVALID_PLAYLIST_ID	-1
 #define MAX_PLAYLISTS		5
 
-#define CONVERTER_PATH		"youtube.michaelbelgium.me/api/converter"
+#define CONVERTER_PATH		"https://youtube.michaelbelgium.me/api/converter/"
 #define MAX_SEARCH_RESULTS 	5
 ```
 

--- a/example.pwn
+++ b/example.pwn
@@ -1,3 +1,5 @@
+#define FILTERSCRIPT
+
 #include <a_samp>
 #include <zcmd>
 #include <sscanf2>
@@ -49,18 +51,18 @@ public OnPlayerDisconnect(playerid, reason)
 CMD:search(playerid, params[])
 {
 	//this example will search for video's, list them in a dialog and when clicking on one of them they will download/play.
-	new mysearch[64];
-	if(sscanf(params, "s[64]", mysearch)) return SendClientMessage(playerid, COLOR_RED, "Usage: /search [something]");
+	new mysearch[128];
+	if(sscanf(params, "s[128]", mysearch) || strlen(mysearch) > 64) return SendClientMessage(playerid, COLOR_RED, "Usage: /search [something]");
 	SearchYoutubeVideos(playerid, mysearch);
 	return 1;
 }
 
 CMD:createmyplaylist(playerid,params[])
 {
-	new name[32], string[128];
+	new name[128], string[128];
 	if(gTotalPlaylists >= MAX_PLAYLISTS) return SendClientMessage(playerid, COLOR_RED, "Reached servers max playlists");
 	if(gMyPlaylist[playerid] != INVALID_PLAYLIST_ID) return SendClientMessage(playerid, COLOR_RED, "You already made a playlist");
-	if(sscanf(params, "s[32]", name)) return SendClientMessage(playerid, COLOR_RED, "Usage: /createmyplaylist [playlist name]");
+	if(sscanf(params, "s[128]", name) || strlen(name) > 32) return SendClientMessage(playerid, COLOR_RED, "Usage: /createmyplaylist [playlist name]");
 	gMyPlaylist[playerid] = CreatePlaylist(name);
 	gTotalPlaylists++;
 
@@ -200,7 +202,7 @@ public OnYoutubeVideoFinished(youtubeid)
 	}
 	else
 	{
-		for(new i = 0, j = GetPlayerPoolSize(); i <= j; i++)
+		for(new i = 0; i < MAX_PLAYERS; i++)
 		{
 			if(gYoutubeID[i] == youtubeid)
 			{
@@ -223,7 +225,7 @@ public OnPlaylistFinished(playlistid)
 	}
 	else
 	{
-		for(new i = 0, j = GetPlayerPoolSize(); i <= j; i++)
+		for(new i = 0; i < MAX_PLAYERS; i++)
 		{
 			if(!IsPlayerConnected(i)) continue;
 			if(gMyPlaylist[i] == playlistid)
@@ -302,8 +304,9 @@ public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 {
 	if(dialogid == DIALOG_SEARCH_AND_PLAY)
 	{
-		if(SearchResults[playerid][listitem][Link][0] == EOS) return 0;
+		if(SearchResults[playerid][listitem][Link][0] == EOS) return 1;
 		PlayYoutubeVideoFor(SearchResults[playerid][listitem][Link], playerid);
+		return 1;
 	}
-	return 1;
+	return 0;
 }

--- a/pawn.json
+++ b/pawn.json
@@ -4,6 +4,6 @@
 	"entry": "test.pwn",
 	"output": "test.amx",
 	"dependencies": [
-		"Hual/SAMPSON"
+		"Southclaws/pawn-requests"
 	]
 }

--- a/test.pwn
+++ b/test.pwn
@@ -8,7 +8,7 @@ main() {
 	for (new i = 0; i < sizeof(youtube_ids); i++) 
 		youtube_ids[i] = INVALID_YT_ID;
 
-	youtube_ids[0] = PlayYoutubeVideoFor("https://www.youtube.com/watch?v=TyHvyGVs42U");
+	youtube_ids[0] = PlayYoutubeVideoFor("https://www.youtube.com/watch?v=ehCQMDKVJqU");
 	SetTimer("OnTest", 10000, false);
 
 	SearchYoutubeVideos(0, "michaelbelgium");
@@ -20,7 +20,7 @@ public OnTest()
 	printSong(0);
 
 	myPlaylist = CreatePlaylist("Playlist 1");
-	youtube_ids[1] = PlayYoutubeVideoFor("https://www.youtube.com/watch?v=uGhKqb2Ow3E", INVALID_PLAYER_ID, myPlaylist);
+	youtube_ids[1] = PlayYoutubeVideoFor("https://www.youtube.com/watch?v=jfreFPe99GU", INVALID_PLAYER_ID, myPlaylist);
 	youtube_ids[2] = PlayYoutubeVideoFor("https://www.youtube.com/watch?v=NkrkAsRVLEA", INVALID_PLAYER_ID, myPlaylist);
 	SetTimer("OnTestPlaylist", 10000, false);
 }


### PR DESCRIPTION
SA-MP [HTTP](https://www.open.mp/docs/scripting/functions/HTTP) and [SAMPSON](https://github.com/Hual/SAMPSON) were replaced with [pawn-requests](https://github.com/Southclaws/pawn-requests). Seems like the default YouTube API is currently down due to some YouTube changes, but I guess it might be useful in the future.

Some notes:
- [Hash-map implementation in PAWN](https://github.com/BigETI/pawn-map) is optional dependency to simplify the process of knowing which player/YouTube ID triggered which request (details: https://github.com/Southclaws/pawn-requests-example/blob/master/test.pwn).
- `EncodeYoutubeURL` encodes only `:` because that's the only character that breaks pawn-requests.
- URLs in `test.pwn` were replaced with videos that are shorter than 3 minutes, so it works with free tier API key.